### PR TITLE
Added pointer to admin button on mobile

### DIFF
--- a/buildsource/bar.css
+++ b/buildsource/bar.css
@@ -122,7 +122,8 @@
   padding: 12px 25px;
   font-size: 1.1em; }
   .admin_bar_mobile .admin_bar_mobile_toggle {
-    display: block; }
+    display: block;
+    cursor: pointer }
 
 .admin_bar_overlay.admin_bar_active {
   position: fixed;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3683927/35593060-df674124-05dc-11e8-8c8e-e2aaefdee12c.png)

I'm working on mobile screens and was trying to hide the admin bar so I could test something out. It occurred to me that I was confused on how to log out. I assumed that it would be in the top right of the admin bar but as I hovered, my mouse did not change to a pointer finger. I think adding a pointer cursor hear would remind the users that this is a button they can click. 